### PR TITLE
Add auto-generated docs to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,3 @@ docs/_build/
 
 # isort output
 /isort.out
-
-# Auto-generated docs
-/docs/modules.rst
-/docs/pysyncgateway.rst

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,18 @@
+Changelog
+=========
+
+All notable changes to this project will be documented in this file.
+
+The format is based on `Keep a Changelog
+<http://keepachangelog.com/en/1.0.0/>`_ and this project adheres to `Semantic
+Versioning <http://semver.org/spec/v2.0.0.html>`_.
+
+
+Unreleased
+----------
+
+
+0.1.3 - 2018/03/26
+------------------
+
+Initial beta release.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Versioning <http://semver.org/spec/v2.0.0.html>`_.
 Unreleased
 ----------
 
+Added
+.....
+
+* Module documentation added to git and RTD.
+
 
 0.1.3 - 2018/03/26
 ------------------

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ endif
 endif
 
 lint_files=pysyncgateway tests setup.py
+rst_files=README.rst CHANGELOG.rst
 
 .PHONY: venv
 venv:
@@ -43,7 +44,7 @@ lint: flake8
 	@echo "=== yapf ==="
 	$(bin_prefix)yapf --recursive --diff $(lint_files)
 	@echo "=== rst ==="
-	$(bin_prefix)restructuredtext-lint README.rst
+	$(bin_prefix)restructuredtext-lint $(rst_files)
 
 .PHONY: tox
 tox:

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,7 @@
+pysyncgateway
+=============
+
+.. toctree::
+   :maxdepth: 4
+
+   pysyncgateway

--- a/docs/pysyncgateway.rst
+++ b/docs/pysyncgateway.rst
@@ -1,0 +1,110 @@
+pysyncgateway package
+=====================
+
+Submodules
+----------
+
+pysyncgateway.admin\_client module
+----------------------------------
+
+.. automodule:: pysyncgateway.admin_client
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pysyncgateway.client module
+---------------------------
+
+.. automodule:: pysyncgateway.client
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pysyncgateway.data\_dict module
+-------------------------------
+
+.. automodule:: pysyncgateway.data_dict
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pysyncgateway.database module
+-----------------------------
+
+.. automodule:: pysyncgateway.database
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pysyncgateway.document module
+-----------------------------
+
+.. automodule:: pysyncgateway.document
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pysyncgateway.exceptions module
+-------------------------------
+
+.. automodule:: pysyncgateway.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pysyncgateway.helpers module
+----------------------------
+
+.. automodule:: pysyncgateway.helpers
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pysyncgateway.query module
+--------------------------
+
+.. automodule:: pysyncgateway.query
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pysyncgateway.resource module
+-----------------------------
+
+.. automodule:: pysyncgateway.resource
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pysyncgateway.stats module
+--------------------------
+
+.. automodule:: pysyncgateway.stats
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pysyncgateway.user module
+-------------------------
+
+.. automodule:: pysyncgateway.user
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pysyncgateway.user\_client module
+---------------------------------
+
+.. automodule:: pysyncgateway.user_client
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: pysyncgateway
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Docs generated by `sphinx-apidoc -f -o docs pysyncgateway/` were not in the repo, so RTD could not find them.

Fixes #11 