### PR TITLE
Extend `Query` to allow views with multiple keys to be queried

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Unreleased_
 See also `latest documentation
 <https://pysyncgateway.readthedocs.io/en/latest/>`_
 
+Changed
+.......
+
+* Adjusted how provided ``key`` values are serialized when querying a view in a
+  Query design document. Now ``key`` values are serialized to JSON allowing for
+  multi-key views to be queried.
+
 
 1.0.0_ - 2018/04/09
 -------------------

--- a/pysyncgateway/query.py
+++ b/pysyncgateway/query.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
+import json
+
 from .resource import Resource
 
 
@@ -113,7 +115,7 @@ class Query(Resource):
         if not stale:
             params['stale'] = 'false'
         if key is not None:
-            params['key'] = '"{}"'.format(key)
+            params['key'] = json.dumps(key)
 
         # Build kwargs (passed to requests.get)
         kwargs = {}

--- a/pysyncgateway/query.py
+++ b/pysyncgateway/query.py
@@ -83,12 +83,17 @@ class Query(Resource):
             view_name (str): View's name.
             key (Optional): Value to use to search the view's key (the
                 left part of the map). Any type can be passed as long as:
-                * ``bool(key) is True``
-                * ``key`` can be converted to string.
-                NOTE: Currently only handles single keys.
+
+                * ``key is not None``
+
+                * ``key`` can be serialized to a string by ``json.dumps()``.
+
+                To query a view with multiple keys set ``key`` as an iterable
+                which will be serialized to JSON as an array. E.g.
+                ``key=['left_id', 'right_id']``.
             stale (bool, Optional): Allow stale results in the view. This is
                 currently the default value in Sync Gateway, so is only passed
-                when set to False. Default ``True``.
+                when set to ``False``. Default ``True``.
 
                 ``'false'`` is an undocumented option for this param. See
                 https://github.com/couchbase/sync_gateway/issues/727#issuecomment-83588984
@@ -97,12 +102,13 @@ class Query(Resource):
                 https://github.com/constructpm/pysyncgateway/issues/7
             timeout (int, Optional): Set a time out of seconds as per requests'
                 spec which means that if the Sync Gateway does not respond to
-                the GET request within the ``timeout`` period a ``ReadTimeout``
+                the GET request within the ``timeout`` period, a ``ReadTimeout``
                 will be raised.  Default ``None`` which means that requests'
                 default is used.
 
         Returns:
-            dict: Decoded JSON for view data result.
+            dict: Decoded JSON for view data result. Will usually be a
+            dictionary contain keys 'Collator', 'rows' and 'total_rows'.
 
         Raises:
             DoesNotExist: When database, design document or contained view can

--- a/tests/query/query_view/test_multi.py
+++ b/tests/query/query_view/test_multi.py
@@ -111,7 +111,7 @@ def test_pupil_query_doc_with_data(pupil_data_design_doc, schools_database):
 
 @pytest.mark.parametrize('keys, expected_names', [
     (['Mel', 'St Barts'], ['Jo', 'Maggy']),
-    ([None, 'St Barts'], ['Chris']),
+    ((None, 'St Barts'), ['Chris']),  # Uses a tuple of keys
     (['Maggy', None], ['Mary']),
     ([None, None], ['Amy']),
 ])
@@ -126,6 +126,8 @@ def test_both_keys(keys, expected_names, pupil_data_design_doc, schools_database
     ('Mel', []),
     ([], 'Olives'),
     ([{}, 'St Barts'], []),
+    ([(), 'St Barts'], []),
+    ([[], 'St Barts'], []),
 ])
 def test_bad(keys, pupil_data_design_doc, schools_database):
     """

--- a/tests/query/query_view/test_multi.py
+++ b/tests/query/query_view/test_multi.py
@@ -1,0 +1,137 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def schools_database(database):
+    """
+    Type: 'pupil'
+
+    =========== ======= ========
+    Name        Parent  School
+    =========== ======= ========
+    Amy
+    Andy        Paul    Olives
+    Chris               St Barts
+    Jo          Mel     St Barts
+    Maggy       Mel     St Barts
+    Mary        Maggy
+    =========== ======= ========
+
+    Returns:
+        Database: Containing pupil information as above. Plus one extra 'class'
+        document and one extra 'teacher' document.
+    """
+    teacher_doc = database.get_document(uuid.uuid4().get_hex())
+    teacher_doc.data = {
+        'type': 'teacher',
+        'school': 'Olives',
+    }
+    teacher_doc.create_update()
+    for name, parent, school in [
+        ('Amy', None, None),
+        ('Andy', 'Paul', 'Olives'),
+        ('Chris', None, 'St Barts'),
+        ('Jo', 'Mel', 'St Barts'),
+        ('Maggy', 'Mel', 'St Barts'),
+        ('Mary', 'Maggy', None),
+    ]:
+        doc = database.get_document(uuid.uuid4().get_hex())
+        doc.data = {
+            'type': 'pupil',
+            'name': name,
+            'parent': parent,
+            'school': school,
+        }
+        doc.create_update()
+    class_doc = database.get_document(uuid.uuid4().get_hex())
+    class_doc.data = {
+        'type': 'class',
+        'subject': 'Geography',
+    }
+    class_doc.create_update()
+    return database
+
+
+def test_schools_database(schools_database):
+    result = schools_database
+
+    all_docs = result.all_docs()
+    assert len(all_docs) == 8
+    [doc.retrieve() for doc in all_docs]
+    not_at_school = filter(lambda doc: 'school' in doc.data and doc.data['school'] is None, all_docs)
+    assert len(not_at_school) == 2
+    assert sorted([doc.data['name'] for doc in not_at_school]) == ['Amy', 'Mary']
+
+
+@pytest.fixture
+def pupil_data_design_doc(database):
+    """
+    Returns:
+        Query: 'pupil_data' design document containing a single view called
+        'list_pupils' which is keyed with `(parent, school)`.
+    """
+    query = database.get_query('pupil_data')
+    query.data = {
+        'views': {
+            'list_pupils': {
+                'map': """
+function (doc,meta) {
+    if(doc.type == "pupil") {
+        emit([doc.parent, doc.school], doc);
+    }
+}
+""",
+            },
+        },
+    }
+    query.create_update()
+    return query
+
+
+def test_pupil_query_doc_empty(pupil_data_design_doc):
+    result = pupil_data_design_doc.query_view('list_pupils')
+
+    assert result['total_rows'] == 0
+
+
+def test_pupil_query_doc_with_data(pupil_data_design_doc, schools_database):
+    result = pupil_data_design_doc.query_view('list_pupils')
+
+    assert result['total_rows'] == 6
+    keys = [row['key'] for row in result['rows']]
+    assert all([len(k) == 2 for k in keys])
+
+
+# --- TESTS ---
+
+
+@pytest.mark.parametrize('keys, expected_names', [
+    (['Mel', 'St Barts'], ['Jo', 'Maggy']),
+    ([None, 'St Barts'], ['Chris']),
+    (['Maggy', None], ['Mary']),
+    ([None, None], ['Amy']),
+])
+def test_both_keys(keys, expected_names, pupil_data_design_doc, schools_database):
+    result = pupil_data_design_doc.query_view('list_pupils', key=keys)
+
+    assert result['total_rows'] == len(expected_names)
+    assert sorted([row['value']['name'] for row in result['rows']]) == expected_names
+
+
+@pytest.mark.parametrize('keys', [
+    ('Mel', []),
+    ([], 'Olives'),
+    ([{}, 'St Barts'], []),
+])
+def test_bad(keys, pupil_data_design_doc, schools_database):
+    """
+    Pinning behaviour of badly formed keys - all give no data and no error.
+    """
+    result = pupil_data_design_doc.query_view('list_pupils', key=keys)
+
+    assert result['total_rows'] == 0
+    assert result['rows'] == []

--- a/tests/query/query_view/test_multi.py
+++ b/tests/query/query_view/test_multi.py
@@ -78,7 +78,8 @@ def pupil_data_design_doc(database):
     query.data = {
         'views': {
             'list_pupils': {
-                'map': """
+                'map':
+                """
 function (doc,meta) {
     if(doc.type == "pupil") {
         emit([doc.parent, doc.school], doc);
@@ -109,12 +110,15 @@ def test_pupil_query_doc_with_data(pupil_data_design_doc, schools_database):
 # --- TESTS ---
 
 
-@pytest.mark.parametrize('keys, expected_names', [
-    (['Mel', 'St Barts'], ['Jo', 'Maggy']),
-    ((None, 'St Barts'), ['Chris']),  # Uses a tuple of keys
-    (['Maggy', None], ['Mary']),
-    ([None, None], ['Amy']),
-])
+@pytest.mark.parametrize(
+    'keys, expected_names',
+    [
+        (['Mel', 'St Barts'], ['Jo', 'Maggy']),
+        ((None, 'St Barts'), ['Chris']),  # Uses a tuple of keys
+        (['Maggy', None], ['Mary']),
+        ([None, None], ['Amy']),
+    ]
+)
 def test_both_keys(keys, expected_names, pupil_data_design_doc, schools_database):
     result = pupil_data_design_doc.query_view('list_pupils', key=keys)
 
@@ -122,13 +126,15 @@ def test_both_keys(keys, expected_names, pupil_data_design_doc, schools_database
     assert sorted([row['value']['name'] for row in result['rows']]) == expected_names
 
 
-@pytest.mark.parametrize('keys', [
-    ('Mel', []),
-    ([], 'Olives'),
-    ([{}, 'St Barts'], []),
-    ([(), 'St Barts'], []),
-    ([[], 'St Barts'], []),
-])
+@pytest.mark.parametrize(
+    'keys', [
+        ('Mel', []),
+        ([], 'Olives'),
+        ([{}, 'St Barts'], []),
+        ([(), 'St Barts'], []),
+        ([[], 'St Barts'], []),
+    ]
+)
 def test_bad(keys, pupil_data_design_doc, schools_database):
     """
     Pinning behaviour of badly formed keys - all give no data and no error.

--- a/tests/query/query_view/test_single.py
+++ b/tests/query/query_view/test_single.py
@@ -44,6 +44,7 @@ def all_query(database_with_doc):
 def test_default(all_query):
     result = all_query.query_view('everything')
 
+    assert sorted(list(result)) == ['Collator', 'rows', 'total_rows']
     assert result['total_rows'] == 1
     assert result['rows'][0]['key'] == 'stuff'
 

--- a/tests/query/query_view/test_single.py
+++ b/tests/query/query_view/test_single.py
@@ -12,7 +12,7 @@ def database_with_doc(database):
     """
     Returns:
         Database: Database with a single document called 'stuff' written to
-            Sync Gateway.
+        Sync Gateway.
     """
     database.get_document('stuff').create_update()
     return database


### PR DESCRIPTION
Views with multiple keys can now be queried with an iterable: `query_doc.query_view('list_stuff', key=['a', 'b'])`

Fixes #25 