### PR TITLE
Add conflict resolution tools

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Unreleased_
 See also `latest documentation
 <https://pysyncgateway.readthedocs.io/en/latest/>`_
 
+Added
+.....
+
+* ``Document.get_open_revisions()`` added to load all leaf revisions of a Document.
+
+* ``Database.bulk_docs()`` added for updating multiple documents and deleting
+  open revisions.
+
 1.1.1_ - 2018/08/17
 -------------------
 

--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,12 @@ fixlint: flake8
 
 .PHONY: doc
 doc:
+	$(MAKE) -C docs clean
 	$(bin_prefix)sphinx-apidoc -f -o docs pysyncgateway/
 	rm docs/modules.rst
 	$(MAKE) -C docs doctest html
+	rm -r /vagrant/html
+	cp -r docs/_build/html /vagrant
 
 
 # --- Building / Publishing ---

--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,15 @@ fixlint: flake8
 
 .PHONY: doc
 doc:
-	$(MAKE) -C docs clean
 	$(bin_prefix)sphinx-apidoc -f -o docs pysyncgateway/
 	rm docs/modules.rst
 	$(MAKE) -C docs doctest html
-	rm -r /vagrant/html
+
+.PHONY: export_doc
+export_doc:
+	$(MAKE) -C docs clean
+	$(MAKE) doc
+	rm -rf /vagrant/html
 	cp -r docs/_build/html /vagrant
 
 

--- a/pysyncgateway/admin_client.py
+++ b/pysyncgateway/admin_client.py
@@ -23,7 +23,7 @@ class AdminClient(Client):
             bool
 
         Raises:
-            ValueError: When `other` is not an AdminClient.
+            ValueError: When ``other`` is not an AdminClient.
         """
         if not isinstance(other, AdminClient):
             raise ValueError('AdminClient compared to {}'.format(type(other)))
@@ -35,13 +35,13 @@ class AdminClient(Client):
         """
         Provide all Databases on the server.
 
-        GET /_all_dbs
+        ``GET /_all_dbs``
 
         Returns:
             list (Database): All databases found, connected with this client.
 
         Raises:
-            GatewayDown: When sync gateway instance can not be reached by
+            .GatewayDown: When sync gateway instance can not be reached by
                 client.
         """
         response = self.get('{}{}'.format(self.url, '_all_dbs')).json()

--- a/pysyncgateway/client.py
+++ b/pysyncgateway/client.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
-from requests import delete, get, put
+from requests import delete, get, post, put
 
 from .database import Database
 from .helpers import ComparableMixin, sg_method
@@ -8,11 +8,11 @@ from .helpers import ComparableMixin, sg_method
 
 class Client(ComparableMixin, object):
     """
-    Abstract parent class for `AdminClient` and `UserClient`.
+    Abstract parent class for ``AdminClient`` and ``UserClient``.
 
     Attributes:
-        _auth (requests.HTTPBasicAuth): Initialises to `None` and is only used
-            by `UserClient`.
+        _auth (requests.HTTPBasicAuth): Initialises to ``None`` and is only
+            used by ``UserClient``.
         url (str): Sync Gateway REST API URL.
     """
     CREATED = 1
@@ -37,7 +37,7 @@ class Client(ComparableMixin, object):
 
     def get_database(self, database_name):
         """
-        Get a `Database` instance connected to this client.
+        Get a ``Database`` instance connected to this client.
 
         Args:
             database_name (str): Name of database.
@@ -54,6 +54,10 @@ class Client(ComparableMixin, object):
         if self._auth:
             kwargs['auth'] = self._auth
         return get(url, **kwargs)
+
+    @sg_method
+    def post(self, url, data):
+        return post(url, json=data)
 
     @sg_method
     def put(self, url, data):

--- a/pysyncgateway/database.py
+++ b/pysyncgateway/database.py
@@ -171,8 +171,8 @@ class Database(ComparableMixin, object):
 
         Args:
             docs (list (Document)): Documents to be created.
-            new_edits (bool): Value for the ``new_edits`` value passed in the
-                ``POST`` data. Defaults to ``False``.
+            new_edits (bool, Optional): Value for the ``new_edits`` value
+                passed in the ``POST`` data. Defaults to ``False``.
 
         Returns:
             bool: Bulk document update was accepted.

--- a/pysyncgateway/database.py
+++ b/pysyncgateway/database.py
@@ -172,7 +172,7 @@ class Database(ComparableMixin, object):
         Args:
             docs (list (Document)): Documents to be created.
             new_edits (bool, Optional): Value for the ``new_edits`` value
-                passed in the ``POST`` data. Defaults to ``False``.
+                passed in the POST data. Defaults to ``False``.
 
         Returns:
             bool: Bulk document update was accepted.

--- a/pysyncgateway/database.py
+++ b/pysyncgateway/database.py
@@ -87,9 +87,9 @@ class Database(ComparableMixin, object):
             dict: Information loaded from SG.
 
         Raises:
-            DoesNotExist: When database is not written to Sync Gateway
+            .DoesNotExist: When database is not written to Sync Gateway
                 regardless of whether the client is authorized or not.
-            ClientUnauthorized: When database exists and client is not
+            .ClientUnauthorized: When database exists and client is not
                 authorized.
         """
         response = self.client.get(self.url)
@@ -148,7 +148,7 @@ class Database(ComparableMixin, object):
             populated with the revision ID from ``value.rev``.
 
         Raises:
-            exceptions.DoesNotExist: Database can't be found on Sync Gateway.
+            .DoesNotExist: Database can't be found on Sync Gateway.
         """
         url = '{}{}'.format(self.url, '_all_docs')
 
@@ -172,7 +172,10 @@ class Database(ComparableMixin, object):
         Args:
             docs (list (Document)): Documents to be created.
             new_edits (bool, Optional): Value for the ``new_edits`` value
-                passed in the POST data. Defaults to ``False``.
+                passed in the POST data. When deleting open revisions, this
+                should be set to ``None`` so that no ``new_edits`` value is
+                sent in the POST data - this is required for the deletion to be
+                successful. Defaults to ``False``.
 
         Returns:
             bool: Bulk document update was accepted.
@@ -184,8 +187,9 @@ class Database(ComparableMixin, object):
 
         data = {
             'docs': [doc.flatten_data() for doc in docs],
-            'new_edits': new_edits,
         }
+        if new_edits is not None:
+            data['new_edits'] = new_edits
 
         response = self.client.post(url, data)
 

--- a/pysyncgateway/database.py
+++ b/pysyncgateway/database.py
@@ -130,16 +130,17 @@ class Database(ComparableMixin, object):
 
         ``GET /:name/_all_docs``
 
-        NOTE Use for testing only. From Simon @ Couchbase:
+        Warning:
+            Use for testing only. From Simon @ Couchbase:
 
-            We would strongly advise against using the `_all_docs` endpoint. As
-            your database grows relying on the View that this calls to return
-            to you every document key is inadvisable and does not scale well to
-            very high numbers of documents.
+                We would strongly advise against using the ``_all_docs``
+                endpoint. As your database grows relying on the View that this
+                calls to return to you every document key is inadvisable and
+                does not scale well to very high numbers of documents.
 
-            If you need to retrieve or update multiple documents please use the
-            _bulk_get and _bulk_docs end points to supply a list of keys (or
-            documents) for retrieval or update.
+                If you need to retrieve or update multiple documents please use
+                the ``_bulk_get`` and ``_bulk_docs`` end points to supply a
+                list of keys (or documents) for retrieval or update.
 
         Returns:
             list (Document): An instance of Document for each document returned
@@ -147,7 +148,7 @@ class Database(ComparableMixin, object):
             populated with the revision ID from ``value.rev``.
 
         Raises:
-            DoesNotExist: Database can't be found on sync gateway.
+            exceptions.DoesNotExist: Database can't be found on Sync Gateway.
         """
         url = '{}{}'.format(self.url, '_all_docs')
 
@@ -161,6 +162,34 @@ class Database(ComparableMixin, object):
             documents.append(document)
 
         return documents
+
+    def bulk_docs(self, docs, new_edits=False):
+        """
+        Update multiple documents.
+
+        ``POST /:name/_bulk_docs``
+
+        Args:
+            docs (list (Document)): Documents to be created.
+            new_edits (bool): Value for the ``new_edits`` value passed in the
+                ``POST`` data. Defaults to ``False``.
+
+        Returns:
+            bool: Bulk document update was accepted.
+
+        Raises:
+            .DoesNotExist: Database can't be found on Sync Gateway.
+        """
+        url = '{}{}'.format(self.url, '_bulk_docs')
+
+        data = {
+            'docs': [doc.flatten_data() for doc in docs],
+            'new_edits': new_edits,
+        }
+
+        response = self.client.post(url, data)
+
+        return response.status_code == 201
 
     # --- Users ---
 

--- a/pysyncgateway/document.py
+++ b/pysyncgateway/document.py
@@ -72,6 +72,20 @@ class Document(Resource):
             raise ValueError('Empty revision received')
         self.rev = revision_id
 
+    def flatten_data(self):
+        """
+        Used when posting multiple documents
+        to the ``_bulk_docs`` endpoint.
+
+        Returns:
+            dict: Data for this document including ``_rev`` and ``_id``.
+        """
+        data = self.data.to_dict()
+        data['_id'] = self.doc_id
+        if self.rev:
+            data['_rev'] = self.rev
+        return data
+
     def create_update(self):
         """
         Save or update Document in Sync Gateway. Saves the received revision id
@@ -111,8 +125,9 @@ class Document(Resource):
 
     def retrieve(self):
         """
-        Load document contents. Once loaded, `_rev` and `channels` are used to
-        update the internal attributes before the data is sent to the DataDict.
+        Load document contents. Once loaded, ``_rev`` and ``channels`` are used
+        to update the internal attributes before the data is sent to the
+        DataDict.
 
         ``GET /<name>/<doc_id>``
 

--- a/pysyncgateway/document.py
+++ b/pysyncgateway/document.py
@@ -27,7 +27,7 @@ class Document(Resource):
             doc_id (str)
 
         Raises:
-            InvalidDocumentID: When doc_id is not valid.
+            .InvalidDocumentID: When doc_id is not valid.
         """
         super(Document, self).__init__(database)
         assert_valid_document_id(doc_id)
@@ -48,7 +48,7 @@ class Document(Resource):
             None
 
         Raises:
-            InvalidChannelName: When a bad channel name is passed.
+            .InvalidChannelName: When a bad channel name is passed.
         """
         for channel in channels:
             assert_valid_channel_name(channel)
@@ -74,8 +74,8 @@ class Document(Resource):
 
     def flatten_data(self):
         """
-        Used when posting multiple documents
-        to the ``_bulk_docs`` endpoint.
+        Used when posting multiple documents with
+        :py:meth:`.Database.bulk_docs()` to the ``/_bulk_docs`` endpoint.
 
         Returns:
             dict: Data for this document including ``_rev`` and ``_id``.
@@ -100,10 +100,10 @@ class Document(Resource):
             int: ``AdminClient.CREATED`` if document was created (matches 201).
 
         Raises:
-            RevisionMismatch: When create (no revision) is tried on an existing
-                Document or update is tried on an existing document, but the
-                revision numbers do not match. Two args are passed to the
-                exception: url of the document and any revision that was
+            .RevisionMismatch: When create (no revision) is tried on an
+                existing Document or update is tried on an existing document,
+                but the revision numbers do not match.  Two args are passed to
+                the exception: url of the document and any revision that was
                 passed with the ``PUT`` request.
         """
 
@@ -135,7 +135,7 @@ class Document(Resource):
             bool: Load was successful.
 
         Raises:
-            DoesNotExist: Document with provided doc_id can not be loaded.
+            .DoesNotExist: Document with provided doc_id can not be loaded.
 
         Note:
             DataDict never contains the private Sync Gateway fields ``_id``,
@@ -174,8 +174,8 @@ class Document(Resource):
         this information when a `delete` is asked for, then a pre-fetch will
         occur.
 
-        Uses the default ``Resource.delete`` action, but then inspects the
-        response to ensure that ``ok`` is ``True``.
+        Uses the default :py:meth:`.Client.delete()` action, but then inspects
+        the response to ensure that ``{"ok": true}``.
 
         ``DELETE /<name>/<doc_id>?rev=<rev>``
 
@@ -183,12 +183,12 @@ class Document(Resource):
             bool: Delete was successful.
 
         Raises:
-            DoesNotExist: If Document can't be found (doc has to be loaded
+            .DoesNotExist: If Document can't be found (doc has to be loaded
                 first to retrieve the revision number, which can yield a 404 if
                 it doesn't exist). Also can be raised if the Database does not
                 exist.
-            RevisionMismatch: Provided ``rev`` parameter did not match the live
-                revision ID on Sync Gateway at request time.
+            .RevisionMismatch: Provided ``rev`` parameter did not match the
+                live revision ID on Sync Gateway at request time.
         """
         if not self.rev:
             self.retrieve()

--- a/pysyncgateway/document.py
+++ b/pysyncgateway/document.py
@@ -20,7 +20,7 @@ class Document(Resource):
             document has been retrieved.
         open_revisions (list (Document)): List of previous revisions as
             Document instances. This will be populated when
-            :py:meth:`.Document.retrive()` is called with ``revs=True``.
+            :py:meth:`.Document.retrieve()` is called with ``revs=True``.
         url (str): URL for this resource on Sync Gateway.
     """
 
@@ -183,10 +183,10 @@ class Document(Resource):
         that one or other is the current document. Therefore this function
         makes two requests:
 
-        * A ``GET`` request using :py:meth:`.Document.retrieve()`. This is used
-            to find the currently winning revision.
+        * A GET request using :py:meth:`.Document.retrieve()`. This is used to
+          find the currently winning revision.
 
-        * A ``GET`` request with ``?open_revs=all`` to collect all leaf nodes.
+        * A GET request with ``?open_revs=all`` to collect all leaf nodes.
 
         The list of leaf nodes is iterated and the currently winning revision
         is used to update this instance. Losing leaf revisions are blown up

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def cleanup_databases():
         bool: admin_client fixture should ignore any existing databases at
         start of test and clean them up.
     """
-    return True
+    return False
 
 
 @pytest.fixture

--- a/tests/database/test_bulk_docs.py
+++ b/tests/database/test_bulk_docs.py
@@ -5,6 +5,45 @@ import pytest
 from pysyncgateway.exceptions import DoesNotExist
 
 
+@pytest.fixture
+def doc_123(database):
+    d_123 = database.get_document('foo')
+    d_123.data = {
+        'type': 'user',
+        'updated_at': '2016-06-24T17:37:49.715Z',
+        'status': 'online',
+    }
+    d_123.set_rev('1-123')
+    return d_123
+
+
+@pytest.fixture
+def doc_456(database):
+    d_456 = database.get_document('foo')
+    d_456.data = {
+        'type': 'user',
+        'updated_at': '2016-06-26T17:37:49.715Z',
+        'status': 'offline',
+    }
+    d_456.set_rev('1-456')
+    return d_456
+
+
+@pytest.fixture
+def doc_789(database):
+    d_789 = database.get_document('foo')
+    d_789.data = {
+        'type': 'user',
+        'updated_at': '2016-06-25T17:37:49.715Z',
+        'status': 'offline',
+    }
+    d_789.set_rev('1-789')
+    return d_789
+
+
+# --- TESTS ---
+
+
 def test_no_docs(database):
     database.create()
 
@@ -33,37 +72,46 @@ def test_new_docs(database):
     assert database.all_docs() == [doc]
 
 
-def test_new_docs_conflicted(database):
+def test_new_docs_conflicted(database, doc_123, doc_456, doc_789):
     """
     Example taken from https://docs.couchbase.com/sync-gateway/1.5/resolving-conflicts.html
     """
     database.create()
-    doc_123 = database.get_document('foo')
-    doc_123.data = {
-        'type': 'user',
-        'updated_at': '2016-06-24T17:37:49.715Z',
-        'status': 'online',
-    }
-    doc_123.set_rev('1-123')
-    doc_456 = database.get_document('foo')
-    doc_456.data = {
-        'type': 'user',
-        'updated_at': '2016-06-26T17:37:49.715Z',
-        'status': 'offline',
-    }
-    doc_456.set_rev('1-456')
-    doc_789 = database.get_document('foo')
-    doc_789.data = {
-        'type': 'user',
-        'updated_at': '2016-06-25T17:37:49.715Z',
-        'status': 'offline',
-    }
-    doc_789.set_rev('1-789')
 
     result = database.bulk_docs([doc_123, doc_456, doc_789])
 
     assert result is True
     assert database.all_docs() == [doc_123]
+    assert doc_123.get_open_revisions() == 3
+    assert doc_123.delete()
+    assert doc_123.retrieve()
+    assert doc_123.rev == '1-456'
+
+
+def test_delete_conflicts(database, doc_123, doc_456, doc_789):
+    """
+    After deleting other revisions, they still come through with
+    get_open_revisions(), but deleting the last revision clears out the
+    document.
+    """
+    database.create()
+    database.bulk_docs([doc_123, doc_456, doc_789])
+    doc_123.to_delete = True
+    doc_456.to_delete = True
+
+    result = database.bulk_docs([doc_123, doc_456], new_edits=None)
+
+    assert result is True
+    assert database.all_docs() == [doc_123]
+    assert doc_123.get_open_revisions() == 3
+    assert [doc.data for doc in doc_123.open_revisions] == [
+        {'_deleted': True},
+        {'_deleted': True},
+    ]
+    assert doc_123.rev == '1-789'
+    assert doc_123.delete()
+    with pytest.raises(DoesNotExist):
+        doc_123.retrieve()
 
 
 # --- FAILURES ---

--- a/tests/database/test_bulk_docs.py
+++ b/tests/database/test_bulk_docs.py
@@ -1,0 +1,74 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+import pytest
+
+from pysyncgateway.exceptions import DoesNotExist
+
+
+def test_no_docs(database):
+    database.create()
+
+    result = database.bulk_docs([])
+
+    assert result is True
+    assert database.all_docs() == []
+
+
+def test_new_docs(database):
+    """
+    Example taken from https://docs.couchbase.com/sync-gateway/1.5/resolving-conflicts.html
+    """
+    database.create()
+    doc = database.get_document('foo')
+    doc.data = {
+        'type': 'user',
+        'updated_at': '2016-06-24T17:37:49.715Z',
+        'status': 'online',
+    }
+    doc.set_rev('1-123')
+
+    result = database.bulk_docs([doc])
+
+    assert result is True
+    assert database.all_docs() == [doc]
+
+
+def test_new_docs_conflicted(database):
+    """
+    Example taken from https://docs.couchbase.com/sync-gateway/1.5/resolving-conflicts.html
+    """
+    database.create()
+    doc_123 = database.get_document('foo')
+    doc_123.data = {
+        'type': 'user',
+        'updated_at': '2016-06-24T17:37:49.715Z',
+        'status': 'online',
+    }
+    doc_123.set_rev('1-123')
+    doc_456 = database.get_document('foo')
+    doc_456.data = {
+        'type': 'user',
+        'updated_at': '2016-06-26T17:37:49.715Z',
+        'status': 'offline',
+    }
+    doc_456.set_rev('1-456')
+    doc_789 = database.get_document('foo')
+    doc_789.data = {
+        'type': 'user',
+        'updated_at': '2016-06-25T17:37:49.715Z',
+        'status': 'offline',
+    }
+    doc_789.set_rev('1-789')
+
+    result = database.bulk_docs([doc_123, doc_456, doc_789])
+
+    assert result is True
+    assert database.all_docs() == [doc_123]
+
+
+# --- FAILURES ---
+
+
+def test_missing_database(database):
+    with pytest.raises(DoesNotExist):
+        database.bulk_docs([])

--- a/tests/database/test_bulk_docs.py
+++ b/tests/database/test_bulk_docs.py
@@ -103,11 +103,8 @@ def test_delete_conflicts(database, doc_123, doc_456, doc_789):
 
     assert result is True
     assert database.all_docs() == [doc_123]
-    assert doc_123.get_open_revisions() == 3
-    assert [doc.data for doc in doc_123.open_revisions] == [
-        {'_deleted': True},
-        {'_deleted': True},
-    ]
+    assert doc_123.get_open_revisions() == 1
+    assert doc_123.open_revisions == []
     assert doc_123.rev == '1-789'
     assert doc_123.delete()
     with pytest.raises(DoesNotExist):

--- a/tests/database/test_get.py
+++ b/tests/database/test_get.py
@@ -62,7 +62,7 @@ def test_missing_unauthed(user_client):
     with pytest.raises(DoesNotExist) as excinfo:
         user_database.get()
 
-    assert 'not found' in excinfo.value.message
+    assert 'not found' in str(excinfo.value)
 
 
 def test_user_unauthed(existing_database, user_client):
@@ -71,4 +71,4 @@ def test_user_unauthed(existing_database, user_client):
     with pytest.raises(ClientUnauthorized) as excinfo:
         user_database.get()
 
-    assert 'Login required' in excinfo.value.message
+    assert 'Login required' in str(excinfo.value)

--- a/tests/database/test_lt.py
+++ b/tests/database/test_lt.py
@@ -49,4 +49,4 @@ def test_other_type():
     with pytest.raises(ValueError) as excinfo:
         database < 1
 
-    assert 'int' in excinfo.value.message
+    assert 'int' in str(excinfo.value)

--- a/tests/document/conftest.py
+++ b/tests/document/conftest.py
@@ -23,3 +23,63 @@ def empty_document(database):
         Document: Empty document not written to sync gateway.
     """
     return Document(database, 'empty_document')
+
+
+@pytest.fixture
+def recipe_document(database):
+    """
+    Returns:
+        Document: Contains a recipe and written to sync gateway.
+    """
+    data = {
+        'ingredients': ['chicken', 'butter'],
+        'recipe': 'Mix the chicken and the butter. Voila!',
+    }
+    document = database.get_document('butter_chicken')
+    document.data = data
+    document.create_update()
+    return document
+
+
+@pytest.fixture
+def permissions_document(database):
+    """
+    Returns:
+        Document: Written to SG with empty data, just channels set.
+    """
+    document = database.get_document('permission-list')
+    document.set_channels('acc.1234', 'acc.7882')
+    document.create_update()
+    return document
+
+
+@pytest.fixture
+def conflicted_document(database):
+    """
+    Returns:
+        Document: Document 'foo' with 3 revisions. Returns the original
+        revision '1-123', but instance is not retrieved.
+    """
+    doc_123 = database.get_document('foo')
+    doc_123.data = {
+        'type': 'user',
+        'updated_at': '2016-06-24T17:37:49.715Z',
+        'status': 'online',
+    }
+    doc_123.set_rev('1-123')
+    doc_456 = database.get_document('foo')
+    doc_456.data = {
+        'type': 'user',
+        'updated_at': '2016-06-26T17:37:49.715Z',
+        'status': 'offline',
+    }
+    doc_456.set_rev('1-456')
+    doc_789 = database.get_document('foo')
+    doc_789.data = {
+        'type': 'user',
+        'updated_at': '2016-06-25T17:37:49.715Z',
+        'status': 'offline',
+    }
+    doc_789.set_rev('1-789')
+    database.bulk_docs([doc_123, doc_456, doc_789])
+    return doc_123

--- a/tests/document/test_fixtures.py
+++ b/tests/document/test_fixtures.py
@@ -12,3 +12,24 @@ def test_empty_document(empty_document):
 
     assert result.data == {}
     assert result.rev == ''
+
+
+def test_recipe_document(recipe_document, database):
+    result = recipe_document
+
+    assert result in database.all_docs()
+
+
+def test_permissions_document(permissions_document, database):
+    result = permissions_document
+
+    assert result in database.all_docs()
+
+
+def test_conflicted_document(conflicted_document, database):
+    result = conflicted_document
+
+    assert database.all_docs() == [result]
+    assert result.rev == '1-123'
+    assert result.retrieve()
+    assert result.rev == '1-789'

--- a/tests/document/test_flatten_data.py
+++ b/tests/document/test_flatten_data.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+
+def test_empty(empty_document):
+    result = empty_document.flatten_data()
+
+    assert result == {
+        '_id': 'empty_document',
+    }
+
+
+def test_empty_with_rev(empty_document):
+    empty_document.set_rev('9-00aabbccddeeff')
+
+    result = empty_document.flatten_data()
+
+    assert result == {
+        '_id': 'empty_document',
+        '_rev': '9-00aabbccddeeff',
+    }
+
+
+def test_some_data_and_rev(database):
+    document = database.get_document('user.999|requirements')
+    document.data = {
+        'updated_at': '2016-06-26T17:37:49.715Z',
+        'status': 'offline',
+    }
+    document.set_rev('101-745062ff812078461f4cc3f7f7b330cf')
+
+    result = document.flatten_data()
+
+    assert result == {
+        '_id': 'user.999|requirements',
+        '_rev': '101-745062ff812078461f4cc3f7f7b330cf',
+        'updated_at': '2016-06-26T17:37:49.715Z',
+        'status': 'offline',
+    }

--- a/tests/document/test_flatten_data.py
+++ b/tests/document/test_flatten_data.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
+import pytest
+
 
 def test_empty(empty_document):
     result = empty_document.flatten_data()
@@ -36,3 +38,33 @@ def test_some_data_and_rev(database):
         'updated_at': '2016-06-26T17:37:49.715Z',
         'status': 'offline',
     }
+
+
+def test_some_data_and_rev_to_delete(database):
+    document = database.get_document('user.999|requirements')
+    document.data = {
+        'updated_at': '2016-06-26T17:37:49.715Z',
+        'status': 'offline',
+    }
+    document.set_rev('101-745062ff812078461f4cc3f7f7b330cf')
+    document.to_delete = True
+
+    result = document.flatten_data()
+
+    assert result == {
+        '_id': 'user.999|requirements',
+        '_rev': '101-745062ff812078461f4cc3f7f7b330cf',
+        '_deleted': True,
+    }
+
+
+# --- FAILURES ---
+
+
+def test_empty_delete(empty_document):
+    empty_document.to_delete = True
+
+    with pytest.raises(ValueError) as excinfo:
+        empty_document.flatten_data()
+
+    assert 'needs a rev' in str(excinfo)

--- a/tests/document/test_get_open_revisions.py
+++ b/tests/document/test_get_open_revisions.py
@@ -1,0 +1,58 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+import pytest
+
+from pysyncgateway.exceptions import DoesNotExist
+
+
+def test_simple(recipe_document):
+    result = recipe_document.get_open_revisions()
+
+    assert result == 1
+    assert recipe_document.open_revisions == []
+
+
+def test_revisions(conflicted_document):
+    """
+    conflicted_document starts at rev 1-123, but it is updated to the current
+    winning revision.
+    """
+    result = conflicted_document.get_open_revisions()
+
+    assert result == 3
+    assert conflicted_document.rev == '1-789'
+    assert conflicted_document.data == {
+        'type': 'user',
+        'updated_at': '2016-06-25T17:37:49.715Z',
+        'status': 'offline',
+    }
+    assert len(conflicted_document.open_revisions) == 2
+    assert conflicted_document.open_revisions[0] == conflicted_document
+    assert conflicted_document.open_revisions[1] == conflicted_document
+    assert sorted([doc.rev for doc in conflicted_document.open_revisions]) == [
+        '1-123',
+        '1-456',
+    ]
+
+
+def test_reload(conflicted_document):
+    conflicted_document.get_open_revisions()
+
+    result = conflicted_document.get_open_revisions()
+
+    assert result == 3
+    assert conflicted_document.rev == '1-789'
+    assert conflicted_document.data == {
+        'type': 'user',
+        'updated_at': '2016-06-25T17:37:49.715Z',
+        'status': 'offline',
+    }
+    assert len(conflicted_document.open_revisions) == 2
+
+
+# --- FAILURES ---
+
+
+def test_missing(empty_document):
+    with pytest.raises(DoesNotExist):
+        empty_document.get_open_revisions()

--- a/tests/document/test_get_open_revisions.py
+++ b/tests/document/test_get_open_revisions.py
@@ -35,6 +35,32 @@ def test_revisions(conflicted_document):
     ]
 
 
+def test_revisions_ignores_deleted(conflicted_document, database):
+    conflicted_document.get_open_revisions()
+    conflicted_document.open_revisions[0].to_delete = True
+    database.bulk_docs(conflicted_document.open_revisions[:1], new_edits=None)
+
+    result = conflicted_document.get_open_revisions()
+
+    assert result == 2
+    assert [doc.rev for doc in conflicted_document.open_revisions] == ['1-456']
+
+
+def test_revisions_include_deleted(conflicted_document, database):
+    conflicted_document.get_open_revisions()
+    conflicted_document.open_revisions[0].to_delete = True
+    conflicted_document.open_revisions[1].to_delete = True
+    database.bulk_docs(conflicted_document.open_revisions, new_edits=None)
+
+    result = conflicted_document.get_open_revisions(include_deleted=True)
+
+    assert result == 3
+    assert [doc.data for doc in conflicted_document.open_revisions] == [
+        {'_deleted': True},
+        {'_deleted': True},
+    ]
+
+
 def test_reload(conflicted_document):
     conflicted_document.get_open_revisions()
 

--- a/tests/document/test_get_open_revisions.py
+++ b/tests/document/test_get_open_revisions.py
@@ -56,8 +56,12 @@ def test_revisions_include_deleted(conflicted_document, database):
 
     assert result == 3
     assert [doc.data for doc in conflicted_document.open_revisions] == [
-        {'_deleted': True},
-        {'_deleted': True},
+        {
+            '_deleted': True
+        },
+        {
+            '_deleted': True
+        },
     ]
 
 

--- a/tests/document/test_init.py
+++ b/tests/document/test_init.py
@@ -9,11 +9,12 @@ from pysyncgateway.exceptions import InvalidDocumentID
 def test(database):
     result = Document(database, '__DOC_ID__')
 
-    assert result.doc_id == '__DOC_ID__'
-    assert result.rev == ''
     assert result.channels == ()
-    assert result.url.endswith('__DOC_ID__')
+    assert result.doc_id == '__DOC_ID__'
     assert result.open_revisions == []
+    assert result.rev == ''
+    assert result.to_delete is False
+    assert result.url.endswith('__DOC_ID__')
 
 
 # --- FAILURES ---

--- a/tests/document/test_init.py
+++ b/tests/document/test_init.py
@@ -13,6 +13,7 @@ def test(database):
     assert result.rev == ''
     assert result.channels == ()
     assert result.url.endswith('__DOC_ID__')
+    assert result.open_revisions == []
 
 
 # --- FAILURES ---

--- a/tests/document/test_retrieve.py
+++ b/tests/document/test_retrieve.py
@@ -5,49 +5,6 @@ import pytest
 from pysyncgateway.exceptions import DoesNotExist
 
 
-@pytest.fixture
-def recipe_document(database):
-    """
-    Returns:
-        Document: Contains a recipe and written to sync gateway.
-    """
-    data = {
-        'ingredients': ['chicken', 'butter'],
-        'recipe': 'Mix the chicken and the butter. Voila!',
-    }
-    document = database.get_document('butter_chicken')
-    document.data = data
-    document.create_update()
-    return document
-
-
-def test_recipe_document(recipe_document, database):
-    result = recipe_document
-
-    assert result in database.all_docs()
-
-
-@pytest.fixture
-def permissions_document(database):
-    """
-    Returns:
-        Document: Written to SG with empty data, just channels set.
-    """
-    document = database.get_document('permission-list')
-    document.set_channels('acc.1234', 'acc.7882')
-    document.create_update()
-    return document
-
-
-def test_permissions_document(permissions_document, database):
-    result = permissions_document
-
-    assert result in database.all_docs()
-
-
-# --- TESTS ---
-
-
 def test(recipe_document, database):
     reload_document = database.get_document('butter_chicken')
 

--- a/tests/document/test_set_channels.py
+++ b/tests/document/test_set_channels.py
@@ -19,4 +19,4 @@ def test_channels_bad(empty_document):
     with pytest.raises(InvalidChannelName) as excinfo:
         empty_document.set_channels('good@1', 'good@2', 'bad#1')
 
-    assert '#' in excinfo.value.message
+    assert '#' in str(excinfo.value)


### PR DESCRIPTION
* `Document.get_open_revisions()` loads all leaf revisions of a Document.
* `Database.bulk_docs()` used for updating multiple documents and deleting open revisions.